### PR TITLE
Show tune type and key in tune list

### DIFF
--- a/scripts/tunelist.gd
+++ b/scripts/tunelist.gd
@@ -14,7 +14,18 @@ func _ready() -> void:
 func add_item(data):
 	var new_item = item.duplicate()
 	item_list.add_child(new_item)
-	new_item.get_node("label").text=data["accented_title"]
+	
+	var meta = []
+	if data["tune_type"] != null:
+		meta.append(data["tune_type"])
+	if data["key_sig"] != null:
+		meta.append(data["key_sig"])
+		
+	var label_text = data["accented_title"]
+	if meta.size() > 0:
+		label_text += "  (" + ", ".join(meta) + ")"
+		
+	new_item.get_node("label").text=label_text
 	new_item.get_node("button").pressed.connect(_button_pressed.bind(new_item.get_node("button"))) #.connect("pressed", self, "_button_pressed",[new_item.get_node("button")])
 	item_data[new_item] = data 
 	new_item.visible=true


### PR DESCRIPTION
## Summary
- Each row in `TunesList` now displays `tune_type` and `key_sig` alongside the accented title, e.g. `Cooley's  (reel, Dmaj)`.
- Null-safe: rows with missing metadata fall back gracefully (only present fields are shown; title alone if both are null).

Addresses #24.

## Test plan
- [x] Open Search Tune; type a few characters; rows show `Title  (tune_type, key_sig)` where data exists.
- [x] Tunes with null `tune_type` or `key_sig` render without `<null>` artifacts.
- [x] My Tunes (Bookmarks) and Random Tune pages still function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)